### PR TITLE
Fix decimal button error after reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,15 +26,15 @@ document.querySelectorAll(".number").forEach((item) => {
 document.querySelectorAll(".operator").forEach((item) => {
   item.addEventListener("click", () => {
     if (storedValue === "") {
-      secondNumber = parseFloat(tempValue);
-      storedValue = parseFloat(tempValue);
+      secondNumber = parseInt(tempValue);
+      storedValue = parseInt(tempValue);
       display.innerText = tempValue;
       operator = item.textContent;
       activeState = "reset";
     } else if (operator === undefined || tempValue === 0) {
       operator = item.textContent;
     } else {
-      storedValue = operate(operator, parseFloat(storedValue), parseFloat(tempValue));
+      storedValue = operate(operator, parseInt(storedValue), parseInt(tempValue));
       display.innerText = storedValue;
       operator = item.textContent;
       activeState = "reset";
@@ -45,11 +45,11 @@ document.querySelectorAll(".operator").forEach((item) => {
 equalsButton.addEventListener("click", () => {
   if (storedValue === "") {
   } else if (operator === undefined) {
-    storedValue = operate(operatorMemory, parseFloat(storedValue), parseFloat(tempValue));
+    storedValue = operate(operatorMemory, parseInt(storedValue), parseInt(tempValue));
     display.innerText = storedValue;
     activeState = "reset";
   } else {
-    storedValue = operate(operator, parseFloat(storedValue), parseFloat(tempValue));
+    storedValue = operate(operator, parseInt(storedValue), parseInt(tempValue));
     operatorMemory = operator;
     operator = undefined;
     display.innerText = storedValue;
@@ -59,7 +59,7 @@ equalsButton.addEventListener("click", () => {
 
 minusButton.addEventListener("click", () => {
   if ((operator === undefined) & (storedValue === "")) {
-    storedValue = parseFloat(tempValue) * -1;
+    storedValue = parseInt(tempValue) * -1;
     display.innerText = storedValue;
     activeState = "reset";
   } else if (operator === undefined) {
@@ -72,8 +72,10 @@ minusButton.addEventListener("click", () => {
 });
 
 decimal.addEventListener("click", () => {
-  if (tempValue.split(".").length < 2) {
-    tempValue = tempValue + ".";
+  // tempValue can be a number after operations or clearing the calculator.
+  // Converting it to a string prevents runtime errors when using split.
+  if (tempValue.toString().split(".").length < 2) {
+    tempValue = tempValue.toString() + ".";
     display.innerText = tempValue;
   }
 });


### PR DESCRIPTION
## Summary
- avoid runtime error by converting numeric `tempValue` to string before calling `.split`

## Testing
- `node - <<'EOF'
const { JSDOM } = require('jsdom');
const fs = require('fs');
const html = fs.readFileSync('index.html', 'utf8');
const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
const scriptCurrent = fs.readFileSync('script.js', 'utf8');
dom.window.eval(scriptCurrent);
dom.window.document.getElementById('clear').click();
try {
  dom.window.document.getElementById('decimal').dispatchEvent(new dom.window.Event('click'));
  console.log('decimal button clicked successfully');
} catch (e) {
  console.error('error', e);
}
EOF

------
https://chatgpt.com/codex/tasks/task_e_683f79e9e858832ba8899c90cb92a23b