### PR TITLE
Add random Bakugan fetch button

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
       <button type="submit">Add</button>
     </form>
     <ul id="task-list"></ul>
+    <section id="bakugan-section">
+      <button id="random-bakugan" type="button">Random Bakugan</button>
+      <div id="bakugan-info"></div>
+    </section>
   </main>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -54,3 +54,38 @@ form.addEventListener("submit", (e) => {
 });
 
 renderTasks();
+
+const randomBtn = document.getElementById("random-bakugan");
+const bakuganInfo = document.getElementById("bakugan-info");
+
+async function fetchBakugan() {
+  if (!bakuganInfo) return;
+  bakuganInfo.textContent = "Loading...";
+  try {
+    const response = await fetch(
+      "https://bakugan.wiki/api.php?action=query&generator=random&grnnamespace=0&prop=extracts|pageimages&exintro=1&explaintext=1&piprop=original&grnlimit=1&format=json&origin=*"
+    );
+    const data = await response.json();
+    const pages = data.query?.pages;
+    const page = pages[Object.keys(pages)[0]];
+    const title = page.title;
+    const description = page.extract;
+    const image = page.original?.source;
+    bakuganInfo.innerHTML = `<h2>${title}</h2>`;
+    if (image) {
+      const img = document.createElement("img");
+      img.src = image;
+      img.alt = title;
+      bakuganInfo.appendChild(img);
+    }
+    const p = document.createElement("p");
+    p.textContent = description;
+    bakuganInfo.appendChild(p);
+  } catch (err) {
+    bakuganInfo.textContent = "Failed to load Bakugan.";
+  }
+}
+
+if (randomBtn) {
+  randomBtn.addEventListener("click", fetchBakugan);
+}

--- a/style.css
+++ b/style.css
@@ -50,3 +50,14 @@ form {
   font-size: 1rem;
   cursor: pointer;
 }
+
+#bakugan-section {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+#bakugan-section img {
+  max-width: 100%;
+  height: auto;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Add button that retrieves a random Bakugan from the wiki and displays its image and description
- Style and layout for Bakugan display section

## Testing
- `npm test` *(fails: enoent, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a68b30fc832b9a2bcfaa4d4a755e